### PR TITLE
Make target repo of build action configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,23 @@ on:
         value: ${{ jobs.generate_image_tags.outputs.ARCHIVEMATICA_MCP_SERVER_IMAGE_TAG}}
       ARCHIVEMATICA_MCP_CLIENT_IMAGE_TAG:
         value: ${{ jobs.generate_image_tags.outputs.ARCHIVEMATICA_MCP_CLIENT_IMAGE_TAG}}
+    inputs:
+      target_repo:
+        type: string
+        required: false
+        default: PermanentOrg/archivematica
   workflow_dispatch:
+    inputs:
+      target_repo:
+        type: string
+        required: false
+        default: PermanentOrg/archivematica
   push:
+    inputs:
+      target_repo:
+        type: string
+        required: false
+        default: PermanentOrg/archivematica
     branches:
       - main
 jobs:
@@ -48,6 +63,8 @@ jobs:
       ARCHIVEMATICA_DASHBOARD_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.ARCHIVEMATICA_DASHBOARD_IMAGE_TAG}}
     steps:
       - uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.target_repo }}
       - run: docker build -t $ARCHIVEMATICA_DASHBOARD_IMAGE_TAG --target archivematica-dashboard -f hack/Dockerfile .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
@@ -65,6 +82,8 @@ jobs:
       ARCHIVEMATICA_MCP_SERVER_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.ARCHIVEMATICA_MCP_SERVER_IMAGE_TAG}}
     steps:
       - uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.target_repo }}
       - run: docker build -t $ARCHIVEMATICA_MCP_SERVER_IMAGE_TAG --target archivematica-mcp-server -f hack/Dockerfile .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
@@ -82,6 +101,8 @@ jobs:
       ARCHIVEMATICA_MCP_CLIENT_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.ARCHIVEMATICA_MCP_CLIENT_IMAGE_TAG}}
     steps:
       - uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.target_repo }}
       - run: docker build -t $ARCHIVEMATICA_MCP_CLIENT_IMAGE_TAG --target archivematica-mcp-client -f hack/Dockerfile .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com


### PR DESCRIPTION
The build action in this repo is intended to be callable from our infrastructure repo as part of an Archivematica deploy. However, when a workflow is called from a separate repo, it runs in the context of that repo, so by default actions/checkout checks out the repo calling the workflow. In this case we want it to actually check out this repo. To achieve that, we make target_repo and input of the build workflow, defaulting to this repo, and use target_repo to explicitly specify what actions/checkout checks out.