### PR TITLE
Increase shutdown timeout for MCPClient

### DIFF
--- a/src/archivematica/MCPClient/client/pool.py
+++ b/src/archivematica/MCPClient/client/pool.py
@@ -144,7 +144,7 @@ class WorkerPool:
 
         for worker in self.workers:
             if worker.is_alive():
-                worker.join(0.1)
+                worker.join(30)
 
         for worker in self.workers:
             if worker.is_alive():


### PR DESCRIPTION
Currently, when we shut down an MCPClient, its workers get 100 ms to finish their jobs before shutting down. Some of the jobs MCPClients do take considerably longer than that. To avoid errors caused by ungraceful shutdowns, this commit increases that timeout to 30 seconds.