### PR TITLE
Increase MAX_QUEUED_PACKAGES to 100,000

### DIFF
--- a/src/archivematica/MCPServer/server/queues.py
+++ b/src/archivematica/MCPServer/server/queues.py
@@ -54,7 +54,7 @@ class PackageQueue:
     """
 
     # An arbitrary, large value, so we don't accept infinite packages.
-    MAX_QUEUED_PACKAGES = 4096
+    MAX_QUEUED_PACKAGES = 100000
 
     def __init__(
         self,


### PR DESCRIPTION
Currently, the MCPServer allows only 4,096 packages to exist in its queue. We sometimes see uploads of as many as ~10,000 packages, which will cause the queue to fill up and subsequent packages to not be processed. This commit fixes that problem by raising the queue limit to 100,000, which is about twice the largest number of uploads we've seen in a single day in the past several years. Items on the queue are quite small, so even 100,000 of them should not cause memory issues.